### PR TITLE
Implemented filterNotNull

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -432,6 +432,19 @@ extension FlowX<T> on Flow<T> {
       await strategy.handle(cacheFlow, this, collector);
     });
   }
+  
+  /// Filters out null from emitted values
+  ///
+  /// Example:
+  /// ```dart
+  ///   flow([1, 2, 3, null, 4, null]).filterNotNull()
+  ///     .collect(print); // This will print only even numbers (1, 2, 3, 4)
+  /// ```
+  Flow<T> filterNotNull() => flow((collector) async {
+    await collect((value) async {
+      if (value != null) collector.emit(value);
+    });
+  });
 }
 
 

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -440,11 +440,7 @@ extension FlowX<T> on Flow<T> {
   ///   flow([1, 2, 3, null, 4, null]).filterNotNull()
   ///     .collect(print); // This will print only even numbers (1, 2, 3, 4)
   /// ```
-  Flow<T> filterNotNull() => flow((collector) async {
-    await collect((value) async {
-      if (value != null) collector.emit(value);
-    });
-  });
+  Flow<T> filterNotNull() => filter((value) => value != null);
 }
 
 

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -81,6 +81,15 @@ extension FlowX<T> on Flow<T> {
       if (await action(value)) collector.emit(value);
     });
   });
+ 
+  /// Filters out null from emitted values
+  ///
+  /// Example:
+  /// ```dart
+  ///   flow([1, 2, 3, null, 4, null]).filterNotNull()
+  ///     .collect(print); // This will print only even numbers (1, 2, 3, 4)
+  /// ```
+  Flow<T> filterNotNull() => filter((value) => value != null);
 
   /// Handles errors that occur within the flow.
   ///
@@ -432,15 +441,7 @@ extension FlowX<T> on Flow<T> {
       await strategy.handle(cacheFlow, this, collector);
     });
   }
-  
-  /// Filters out null from emitted values
-  ///
-  /// Example:
-  /// ```dart
-  ///   flow([1, 2, 3, null, 4, null]).filterNotNull()
-  ///     .collect(print); // This will print only even numbers (1, 2, 3, 4)
-  /// ```
-  Flow<T> filterNotNull() => filter((value) => value != null);
+
 }
 
 

--- a/test/flow_test.dart
+++ b/test/flow_test.dart
@@ -160,5 +160,21 @@ void main() {
       'NotEmpty', emitsDone
     ]));
   });
+
+  test('Test that .filterNotNull filters out null from emitted values', () async {
+    final fl = flow<String?>((collector) {
+      collector.emit("A");
+      collector.emit("B");
+      collector.emit("C");
+      collector.emit(null);
+      collector.emit(null);
+      collector.emit('D');
+    })
+    .filterNotNull();
+
+    expect(fl.asStream(), emitsInOrder([
+      'A', 'B', 'C', 'D'
+    ]));
+  });
 }
 


### PR DESCRIPTION
This function filters out null from emitted values
  
Example:
```dart
   flow([1, 2, 3, null, 4, null]).filterNotNull()
   .collect(print); // This will print only even numbers (1, 2, 3, 4)
 ```