### PR TITLE
Implemented map not null

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -36,6 +36,37 @@ extension FlowX<T> on Flow<T> {
     await collect((value) async => collector.emit(await transform(value)));
   });
 
+  /// Returns a flow that contains only non-null results of applying the
+  /// given transform function to each value of the original flow
+  ///
+  /// Example:
+  /// ```dart
+  /// final fl = flow<int>((collector) {
+  ///     collector.emit(1);
+  ///     collector.emit(2);
+  ///     collector.emit(3);
+  ///     collector.emit(4);
+  ///   })
+  ///   .mapNotNull((value) {
+  ///     if (value % 2 == 0) {
+  ///       return value;
+  ///     }
+  ///     return null;
+  ///   }).collect(print)
+  ///  
+  /// This will print (2, 4)
+  /// ```
+  /// [transform] : A function that takes a value of type `T` (the input
+  /// type of the flow) and returns a value of type `U` (the output type
+  /// of the map operation).
+  Flow<U> mapNotNull<U>(FutureOr<U> Function(T value) transform) =>
+      flow((collector) async {
+        await collect((value) async {
+          final result = await transform(value);
+          if (result != null) collector.emit(result);
+        });
+      });
+
   /// Applies a transformation function and flattens the resulting streams.
   ///
   /// This function is similar to `map` but allows transforming each element
@@ -88,7 +119,7 @@ extension FlowX<T> on Flow<T> {
   /// Example:
   /// ```dart
   ///   flow([1, 2, 3, null, 4, null]).filterNotNull()
-  ///     .collect(print); // This will print only even numbers (1, 2, 3, 4)
+  ///     .collect(print); // This will print only numbers (1, 2, 3, 4)
   /// ```
   Flow<T> filterNotNull() => filter((value) => value != null);
 

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -59,13 +59,12 @@ extension FlowX<T> on Flow<T> {
   /// [transform] : A function that takes a value of type `T` (the input
   /// type of the flow) and returns a value of type `U` (the output type
   /// of the map operation).
-  Flow<U> mapNotNull<U>(FutureOr<U> Function(T value) transform) =>
-      flow((collector) async {
-        await collect((value) async {
-          final result = await transform(value);
-          if (result != null) collector.emit(result);
-        });
-      });
+  Flow<U> mapNotNull<U>(FutureOr<U> Function(T value) transform) => flow((collector) async {
+    await collect((value) async {
+      final result = await transform(value);
+      if (result != null) collector.emit(result);
+    });
+  });
 
   /// Applies a transformation function and flattens the resulting streams.
   ///

--- a/test/flow_test.dart
+++ b/test/flow_test.dart
@@ -176,6 +176,24 @@ void main() {
       'A', 'B', 'C', 'D'
     ]));
   });
+
+  test('Test that .mapNotNull returns a flow that contains only non-null results', () {
+    final fl = flow<int>((collector) {
+      collector.emit(1);
+      collector.emit(2);
+      collector.emit(3);
+      collector.emit(4);
+    })
+    .mapNotNull((value) {
+      if (value % 2 == 0) {
+        return value;
+      }
+      return null;
+    });
+
+    expect(fl.asStream(), emitsInOrder([
+      2, 4]));
+  });
   
   group('Timeout', () {
     test('Test that when the timeout expires a TimeoutCancellationException is thrown', () async {


### PR DESCRIPTION
Implemented MapNotNull

Returns a flow that contains only non-null results of applying the
given transform function to each value of the original flow

Example:
```dart
final fl = flow<int>((collector) {
  collector.emit(1);
  collector.emit(2);
  collector.emit(3);
  collector.emit(4);
})
.mapNotNull((value) {
  if (value % 2 == 0) {
     return value;
  }
  return null;
}).collect(print)
```
 
This will print (2, 4)