### PR TITLE
Standardize Time Parameter Handling Using Duration Instead of Integers

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -578,3 +578,12 @@ extension StreamX<T> on Stream<T> {
     });
   }
 }
+
+extension DurationX on num {
+  Duration get microseconds => Duration(microseconds: toInt());
+  Duration get milliseconds => Duration(milliseconds: toInt());
+  Duration get seconds => Duration(seconds: toInt());
+  Duration get minutes => Duration(minutes: toInt());
+  Duration get hours => Duration(hours: toInt());
+  Duration get days => Duration(days: toInt());
+}

--- a/test/retries_test.dart
+++ b/test/retries_test.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:flow/flow.dart';
-import 'package:flow/src/retries.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 main() {
@@ -18,7 +16,10 @@ main() {
         if (emission < 3) throw Exception('hello');
         collector.emit('B');
       }).onStart((_) => stopWatch.start()).retryWith((cause) {
-        return RetryPolicy.exponentialBackOff(baseDelay: 1000, maxAttempts: 6);
+        return RetryPolicy.exponentialBackOff(
+          baseDelay: 1000.milliseconds,
+          maxAttempts: 6,
+        );
       }).onCompletion((p0, p1) {
         stopWatch.stop();
         completer.complete(stopWatch.elapsedMilliseconds);
@@ -42,9 +43,9 @@ main() {
 
       final circuitBreaker = RetryPolicy.circuitBreaker(
           failureThreshold: 4,
-          resetTimeout: 500,
+          resetTimeout: 500.milliseconds,
           halfOpenThreshold: 2,
-          coolDownTime: (start: 200, end: 400)
+          coolDownTime: (start: 200.milliseconds, end: 400.milliseconds)
       );
 
       const totalNoOfEmission = 7;
@@ -91,7 +92,7 @@ main() {
   group('FixedIntervalRetryPolicy Tests', () {
     test('Retry respects fixed delay', () async {
       const maxAttempts = 5;
-      const delay = 3000;
+      final delay = 3000.milliseconds;
       final policy = RetryPolicy.fixedInterval(delay: delay, maxAttempts: maxAttempts); // Using shorter delays for tests
       final stopwatch = Stopwatch()..start();
 
@@ -101,7 +102,7 @@ main() {
 
       // Check that the elapsed time is at least the specified delay.
       // In a real test, you might mock the delay or abstract time to avoid waiting.
-      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(delay));
+      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(delay.inMilliseconds));
     });
 
     test('Max attempts limit is respected', () async {
@@ -123,7 +124,7 @@ main() {
   group('DecorrelatedJitterRetryPolicy Tests', () {
     test('Initial retry delay is baseDelay', () async {
 
-      const baseDelay = 2000;
+      final baseDelay = 2000.milliseconds;
 
       final policy = RetryPolicy.decorrelatedJitter(baseDelay: baseDelay);
       final stopwatch = Stopwatch()..start();
@@ -133,7 +134,7 @@ main() {
       stopwatch.stop();
 
       // The first delay should be at least baseDelay.
-      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(baseDelay));
+      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(baseDelay.inMilliseconds));
     });
 
     test('Max attempts limit is respected', () async {
@@ -164,7 +165,11 @@ main() {
         if (emission < 2) throw Exception('hello');
         collector.emit('B');
       }).onStart((_) => stopWatch.start()).retryWith((cause) {
-        return RetryPolicy.randomisedBackoff(baseDelay: 1000, maxAttempts: 6,maxDelay: 1500);
+        return RetryPolicy.randomisedBackoff(
+          baseDelay: 1000.milliseconds,
+          maxAttempts: 6,
+          maxDelay: 1500.milliseconds,
+        );
       }).onCompletion((p0, p1) {
         stopWatch.stop();
         completer.complete(stopWatch.elapsedMilliseconds);
@@ -193,7 +198,10 @@ main() {
         if (emission < 4) throw Exception('hello');
         collector.emit('B');
       }).onStart((_) => stopWatch.start()).retryWith((cause) {
-        return RetryPolicy.linearBackoff(baseDelay: 1000,maxDelay: 4000);
+        return RetryPolicy.linearBackoff(
+          baseDelay: 1000.milliseconds,
+          maxDelay: 4000.milliseconds,
+        );
       }).onCompletion((p0, p1) {
         stopWatch.stop();
         completer.complete(stopWatch.elapsedMilliseconds);


### PR DESCRIPTION
Addresses issue #25 