### PR TITLE
Hide duration extension

### DIFF
--- a/lib/flow.dart
+++ b/lib/flow.dart
@@ -1,6 +1,6 @@
 library flow;
 export 'src/flowimpl.dart';
-export 'src/extensions.dart';
+export 'src/extensions.dart' hide DurationX;
 export 'src/builders.dart';
 export 'src/operators/cache.dart';
 export 'src/exceptions/flow_exception.dart' hide ErrorX;

--- a/test/retries_test.dart
+++ b/test/retries_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flow/flow.dart';
+import 'package:flow/src/extensions.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 main() {


### PR DESCRIPTION
Currently the DurationX extension is being exposed, hid it from being exported