### PR TITLE
Added functionality to get a CombinedFlowException errors by type

### DIFF
--- a/lib/src/exceptions/flow_exception.dart
+++ b/lib/src/exceptions/flow_exception.dart
@@ -17,6 +17,17 @@ class CombinedFlowException implements Exception {
     errors.add(exception);
   }
 
+  /// Safely retrieves an exception of type T from the errors list.
+  /// If `T` is not found, returns `null`.
+  T? get<T>() {
+    for (var error in errors) {
+      if (error is T) {
+        return error;
+      }
+    }
+    return null;
+  }
+
   @override
   String toString() {
     return 'CombinedFlowException(${errors.join(',')})';

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -297,6 +297,24 @@ main() {
       2, emitsDone
     ]));
   });
+
+  test(
+      'should retrieve the first error '
+      'that matches specified type T', () {
+    final fl = flow((collector) {
+      throw CombinedFlowException([
+        FlowException(Exception('test exception')),
+        TimeoutCancellationException(1.seconds),
+      ]);
+    });
+
+    expect(
+        fl.asStream(),
+        emitsError(isA<CombinedFlowException>()
+            .having((a) => a.get<TimeoutCancellationException>(),
+            'MatchingType', isA<TimeoutCancellationException>()))
+    );
+  });
 }
 
 class TestCacheFlow<T> extends CacheFlow<T> {


### PR DESCRIPTION
A CombinedFlowException returns errors either that can occur either from the cache or from external datasources call e.g remote.  In most cases we can be more concerned about a particular exception we care to handle at a particular layer of our application. 

```dart
flow((collector) {
   final exceptions = [FlowException(Exception('originalCause')), TimeoutCancellationException(1.seconds)];
   throw CombinedFlowException(exceptions);
 })
 .catchError((error, collector) {
   if (error is CombinedFlowException && error.get<TimeoutCancellationException>() != null) {
     // do xyz in cancellation
     return;
  }
 throw error;
});
```