### PR TITLE
implemented toString in FlowException

### DIFF
--- a/lib/src/exceptions/flow_exception.dart
+++ b/lib/src/exceptions/flow_exception.dart
@@ -7,6 +7,9 @@ class CancellationException implements Exception {
 class FlowException implements Exception {
   final Object? cause;
   FlowException(this.cause);
+
+  @override
+  String toString() => "FlowException($cause)";
 }
 
 class CombinedFlowException implements Exception {


### PR DESCRIPTION
FlowException currently doesn't display the cause of the exception via toString(). 

Implemented toString() to enable this display